### PR TITLE
[FEAT] 크루 리스트 조회 api 연동 

### DIFF
--- a/src/entities/crew/api/getCrewFile.ts
+++ b/src/entities/crew/api/getCrewFile.ts
@@ -1,0 +1,18 @@
+import { privateClient } from '@/shared/api/config';
+import { FileResponse } from '@/shared/types/api';
+
+export interface GetCrewFileRequest {
+  crewId: number;
+}
+
+export const getCrewFile = async ({ crewId }: GetCrewFileRequest): Promise<FileResponse> => {
+  const { data: response } = await privateClient(`/file/${crewId}`, {
+    params: { type: 'crew' },
+  });
+
+  return {
+    fileId: response.data.fileId,
+    source: response.data.source,
+    fileEnv: response.data.fileEnv,
+  };
+};

--- a/src/entities/crew/api/postCrewFile.ts
+++ b/src/entities/crew/api/postCrewFile.ts
@@ -1,17 +1,12 @@
 import { privateClient } from '@/shared/api/config';
+import { FileResponse } from '@/shared/types/api';
 
 export interface PostCrewFileRequest {
   crewId: number;
   files: File[];
 }
 
-export interface PostCrewFileResponse {
-  fileId: number;
-  source: string;
-  fileEnv: 'LOCAL' | 'CLOUD';
-}
-
-export const postCrewFile = async ({ crewId, files }: PostCrewFileRequest): Promise<PostCrewFileResponse> => {
+export const postCrewFile = async ({ crewId, files }: PostCrewFileRequest): Promise<FileResponse> => {
   const formData = new FormData();
   files.forEach((file) => formData.append('files', file));
 

--- a/src/features/auth/api/getAuthProfileImage.ts
+++ b/src/features/auth/api/getAuthProfileImage.ts
@@ -1,12 +1,7 @@
 import { publicClient } from '@/shared/api/config';
+import { FileResponse } from '@/shared/types/api';
 
-export interface AuthProfileImageResponse {
-  fileEnv: 'LOCAL' | 'CLOUD';
-  fileId: number;
-  source: string;
-}
-
-export const getAuthProfileImage = async (token: string): Promise<AuthProfileImageResponse> => {
+export const getAuthProfileImage = async (token: string): Promise<FileResponse> => {
   const { data: response } = await publicClient.get(`/auth/profile?token=${token}`);
   const { data } = response;
   const { fileEnv, fileId, source } = data;

--- a/src/features/crew/api/getMyCrewList.ts
+++ b/src/features/crew/api/getMyCrewList.ts
@@ -1,0 +1,38 @@
+import { privateClient } from '@/shared/api/config';
+
+export interface GetMyCrewListRequest {
+  size: number;
+  page: number;
+}
+
+export interface GetMyCrewListResponse {
+  content: Crew[];
+  page: Page;
+}
+
+export interface Page {
+  size: number;
+  number: number;
+  totalPages: number;
+  totalElements: number;
+}
+
+export interface Crew {
+  crewId: number;
+  name: string;
+  participantCount: number;
+}
+
+export const getMyCrewList = async ({ size, page }: GetMyCrewListRequest): Promise<GetMyCrewListResponse> => {
+  const { data: response } = await privateClient.get('/crew/my', {
+    params: {
+      page: page,
+      size: size,
+    },
+  });
+
+  return {
+    content: response.data.content,
+    page: response.data.page,
+  };
+};

--- a/src/features/crew/query/crewQueries.ts
+++ b/src/features/crew/query/crewQueries.ts
@@ -1,0 +1,20 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getMyCrewList, GetMyCrewListRequest, GetMyCrewListResponse } from '../api/getMyCrewList';
+import { getCrewFile, GetCrewFileRequest } from '@/entities/crew/api/getCrewFile';
+
+export const crewQueries = {
+  allKeys: ['crew'] as const,
+  myAllCrewKeys: ['myCrew'] as const,
+
+  crewFile: ({ crewId }: GetCrewFileRequest) =>
+    queryOptions({
+      queryKey: [...crewQueries.allKeys, 'file', crewId],
+      queryFn: () => getCrewFile({ crewId }),
+    }),
+
+  myCrewList: ({ page, size }: GetMyCrewListRequest) =>
+    queryOptions<GetMyCrewListResponse>({
+      queryKey: [...crewQueries.myAllCrewKeys, 'list', page, size],
+      queryFn: () => getMyCrewList({ page, size }),
+    }),
+};

--- a/src/features/crew/query/useCrewsWithFile.ts
+++ b/src/features/crew/query/useCrewsWithFile.ts
@@ -1,0 +1,38 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { crewQueries } from './crewQueries';
+import { FileResponse } from '@/shared/types/api';
+
+// 크루와 이미지를 합병하는 커스텀 훅
+export const useMyCrewsWithImages = (page: number, size: number) => {
+  const { data: crewListData } = useQuery({
+    ...crewQueries.myCrewList({ page, size }),
+  });
+
+  const fileQueries = useQueries({
+    queries: (crewListData?.content || []).map((crew) => ({
+      ...crewQueries.crewFile({ crewId: crew.crewId }),
+    })),
+  });
+
+  // 파일 데이터를 ID로 매핑
+  const fileDataMap: Record<number, FileResponse | undefined> = {};
+  crewListData?.content?.forEach((crew, index) => {
+    fileDataMap[crew.crewId] = fileQueries[index]?.data;
+  });
+
+  // 매핑을 사용하여 content 변환
+  const enhancedContent = crewListData?.content?.map((crew) => ({
+    ...crew,
+    file: fileDataMap[crew.crewId],
+  }));
+
+  // 변환된 데이터만 반환
+  return {
+    data: crewListData
+      ? {
+          ...crewListData,
+          content: enhancedContent || [],
+        }
+      : undefined,
+  };
+};

--- a/src/pages/CrewCreatePage/index.tsx
+++ b/src/pages/CrewCreatePage/index.tsx
@@ -1,9 +1,11 @@
+import { routePaths } from '@/app/routes/path';
 import { usePostCrew } from '@/entities/crew/query/usePostCrew';
 import { usePostCrewFile } from '@/entities/crew/query/usePostCrewFile';
 import { useCrewRegister } from '@/features/crew/model/useCrewRegister';
 import CrewForm from '@/features/crew/ui/CrewForm';
 import { TitledFormLayout } from '@/shared/ui/TitledFormLayout';
 import { FormEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 function CrewCreatePage() {
   const { formMethods, handleFileInputClick, mergedRef } = useCrewRegister({
@@ -13,6 +15,7 @@ function CrewCreatePage() {
   });
   const { mutateAsync: postCrew } = usePostCrew();
   const { mutateAsync: postCrewFile } = usePostCrewFile();
+  const navigate = useNavigate();
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -27,6 +30,7 @@ function CrewCreatePage() {
 
     const { crewId } = await postCrew({ name: crewName, introduce: crewIntroduce });
     if (files.length > 0) await postCrewFile({ crewId, files });
+    navigate(routePaths.main);
   };
 
   return (

--- a/src/shared/hooks/usePagination.ts
+++ b/src/shared/hooks/usePagination.ts
@@ -12,15 +12,24 @@ export interface PaginationHookReturn {
   handleClickNextPage: () => void;
   handleClickPrevPages: () => void;
   handleClickNextPages: () => void;
+  setMaxPage: (newMaxPage: number) => void;
+  setMinPage: (newMinPage: number) => void;
 }
 
-export const usePagination = (minPage: number, maxPage: number, blockSize: number = 6): PaginationHookReturn => {
+export const usePagination = (
+  initialMinPage: number,
+  initialMaxPage: number,
+  blockSize: number = 6,
+): PaginationHookReturn => {
   if (blockSize < 7) {
     throw new Error('blockSize는 7 이상이어야합니다.');
   }
   const END_BLOCK_SIZE = blockSize - 1;
   const MIDDLE_BLOCK_SIZE = blockSize - 4;
 
+  // maxPage를 상태로 관리
+  const [maxPage, setMaxPage] = useState(initialMaxPage);
+  const [minPage, setMinPage] = useState(initialMinPage);
   const [currentPage, setCurrentPage] = useState(minPage);
   const [visiblePages, setVisiblePages] = useState<Page[]>([]);
 
@@ -80,6 +89,8 @@ export const usePagination = (minPage: number, maxPage: number, blockSize: numbe
     visiblePages,
     minPage,
     maxPage,
+    setMaxPage,
+    setMinPage,
     handleClickPage,
     handleClickPrevPage,
     handleClickNextPage,

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,0 +1,5 @@
+export interface FileResponse {
+  fileId: number;
+  source: string;
+  fileEnv: 'LOCAL' | 'CLOUD';
+}

--- a/src/widgets/crew/ParticipatingCrewList/index.tsx
+++ b/src/widgets/crew/ParticipatingCrewList/index.tsx
@@ -1,46 +1,42 @@
 import { Card } from '@/shared/ui/Card';
-import image from '@/shared/assets/temp.jpg';
 import { usePagination } from '@/shared/hooks/usePagination';
 import Pagination from '@/shared/ui/Pagination';
 import styles from './index.module.scss';
 import GridContainer from '@/shared/ui/GridContainer';
-
-const datas = [
-  { id: 1, name: 'testtttttttttttttttttttttttttt', image, participants: 5 },
-  { id: 2, name: 'test', image, participants: 10 },
-  { id: 3, name: 'test', image, participants: 12 },
-  { id: 4, name: 'test', image, participants: 20 },
-  { id: 5, name: 'test', image, participants: 25 },
-  { id: 6, name: 'test', image, participants: 18 },
-  { id: 7, name: 'test', image, participants: 21 },
-  { id: 8, name: 'test', image, participants: 11 },
-  { id: 9, name: 'test', image, participants: 26 },
-  { id: 10, name: 'test', image, participants: 12 },
-  { id: 11, name: 'test', image, participants: 27 },
-  { id: 12, name: 'test', image, participants: 19 },
-  { id: 13, name: 'test', image, participants: 27 },
-  { id: 14, name: 'test', image, participants: 19 },
-];
+import { useEffect } from 'react';
+import { useMyCrewsWithImages } from '@/features/crew/query/useCrewsWithFile';
+import temp from '@/shared/assets/temp.jpg';
 
 function ParticipatingCrewList() {
-  const paginationTools = usePagination(1, 19, 7);
+  const paginationTools = usePagination(1, 1, 7);
+  const { currentPage, setMaxPage } = paginationTools;
+  const { data: crewListData } = useMyCrewsWithImages(currentPage - 1, 12);
+
+  useEffect(() => {
+    if (crewListData?.page?.totalPages) setMaxPage(crewListData.page.totalPages);
+  }, [crewListData?.page?.totalPages, setMaxPage]);
+
+  if (!crewListData) return null;
+  const { content } = crewListData;
 
   return (
     <div className={styles.crewList}>
       <GridContainer>
-        {datas.map((data) => {
+        {content.map((crew) => {
           return (
-            <Card key={data.id}>
-              <Card.Image src={data.image} alt="크루 썸네일" />
-              <Card.Title>{data.name}</Card.Title>
-              <Card.Detail>크루원 {data.participants}</Card.Detail>
+            <Card key={crew.crewId}>
+              <Card.Image src={crew.file?.source || temp} alt="크루 썸네일" />
+              <Card.Title>{crew.name}</Card.Title>
+              <Card.Detail>크루원 {crew.participantCount}</Card.Detail>
             </Card>
           );
         })}
       </GridContainer>
-      <div className={styles.crewListPagination}>
-        <Pagination paginationTools={paginationTools} />
-      </div>
+      {crewListData.page.totalPages > 0 && (
+        <div className={styles.crewListPagination}>
+          <Pagination paginationTools={paginationTools} />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 🔥 PR 개요

<!-- PR의 목적을 간략히 설명해주세요. -->

- 크루 리스트 조회 api 연동 

## 📌 주요 변경 사항

<!-- 변경된 내용을 상세히 적어주세요. -->

- `ParticipatingCrewList` 컴포넌트 데이터 api 연동 
  - 크루 목록을 조회하고, 크루별 썸네일 이미지를 표시
  - `usePagination` 훅을 활용한 페이지네이션 부착 
  - `useMyCrewsWithImages` 훅을 활용하여 크루 리스트와 이미지 결합 

- `useMyCrewsWithImages` 커스텀 훅 추가
  - 크루 목록(`myCrewList`)과 각 크루의 이미지(`crewFile`)를 병합
  - `useQueries`를 사용하여 크루별 이미지 데이터 병렬 요청

- 페이지네이션 개선
  - `useEffect`를 활용하여 API 응답에 따라 `setMaxPage`를 동적으로 업데이트
  - 크루 데이터가 있을 때만 페이지네이션 표시

## 🔗 관련 이슈

- Closes #31 

## 🔍 테스트 방법

<!-- 변경된 기능을 테스트하는 방법을 설명해주세요. -->

1. `yarn dev` 실행
2. /signin 로그인 
3. /main 크루 생성 후 크루 리스트 확인 

## 📷 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

## 📢 리뷰 요구 사항 (선택)

<!-- 리뷰어에게 요구 사항이 있다면 적어주세요.. -->

## 📜 기타 참고 사항 (선택)

<!-- 추가적으로 참고할 사항이 있다면 적어주세요. -->


## ✅ 체크리스트

<!-- 아래 항목을 확인하고 `[x]`로 표시해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 관련 이슈를 Closes #이슈번호로 닫았나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 관련 문서를 업데이트했나요?
