### PR TITLE
[FEAT] 크루의 모먼트 리스트 api 연동 

### DIFF
--- a/src/app/routes/path.ts
+++ b/src/app/routes/path.ts
@@ -12,9 +12,13 @@ export const routePaths = {
     path: '/crew/:crewId/moment/create',
     getPath: (crewId: number) => `/crew/${crewId}/moment/create`,
   },
-  momentPlace: {
+  momentDetail: {
     path: '/crew/:crewId/moment/:momentId',
     getPath: (crewId: number, momentId: number) => `/crew/${crewId}/moment/${momentId}`,
+  },
+  momentPlace: {
+    path: '/crew/:crewId/moment/:momentId/place',
+    getPath: (crewId: number, momentId: number) => `/crew/${crewId}/moment/${momentId}/place`,
   },
   chat: '/chat/:crewId',
 };

--- a/src/entities/moment/api/getMomentFile.ts
+++ b/src/entities/moment/api/getMomentFile.ts
@@ -1,0 +1,21 @@
+import { privateClient } from '@/shared/api/config';
+import { formatImageSource } from '@/shared/helper/formatImageSource';
+import { FileType } from '@/shared/types/api';
+
+export interface GetMomentFileRequest {
+  momentId: number;
+}
+
+export const getMomentFile = async ({ momentId }: GetMomentFileRequest): Promise<FileType> => {
+  const { data: response } = await privateClient(`/file/${momentId}`, {
+    params: { type: 'moment' },
+  });
+
+  const { fileId, source, fileEnv } = response.data;
+
+  return {
+    fileId: fileId,
+    source: formatImageSource(fileEnv, source),
+    fileEnv: fileEnv,
+  };
+};

--- a/src/entities/moment/model/types.ts
+++ b/src/entities/moment/model/types.ts
@@ -1,13 +1,14 @@
 import { FileType } from '@/shared/types/api';
 
 export interface MomentJSONType {
-  crewId: number;
+  momentId: number;
+  status: '참여가능' | '참여중' | '마감';
   name: string;
-  date: string;
-  location: string;
-  capacity: number;
+  meetAt: string;
+  meetingPlaceName: string;
   participantCount: number;
-  endDate: string;
+  capacity: number;
+  closedAt: string;
 }
 
 export interface MomentType extends MomentJSONType {

--- a/src/entities/moment/query/momentQueries.ts
+++ b/src/entities/moment/query/momentQueries.ts
@@ -1,0 +1,12 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getMomentFile, GetMomentFileRequest } from '../api/getMomentFile';
+
+export const momentQueries = {
+  allKeys: ['crewMoment'] as const,
+
+  momentFile: ({ momentId }: GetMomentFileRequest) =>
+    queryOptions({
+      queryKey: [...momentQueries.allKeys, 'file', momentId],
+      queryFn: () => getMomentFile({ momentId }),
+    }),
+};

--- a/src/features/crew/api/getMyCrewList.ts
+++ b/src/features/crew/api/getMyCrewList.ts
@@ -1,20 +1,9 @@
 import { privateClient } from '@/shared/api/config';
+import { Pagination } from '@/shared/types/api';
 
 export interface GetMyCrewListRequest {
   size: number;
   page: number;
-}
-
-export interface GetMyCrewListResponse {
-  content: Crew[];
-  page: Page;
-}
-
-export interface Page {
-  size: number;
-  number: number;
-  totalPages: number;
-  totalElements: number;
 }
 
 export interface Crew {
@@ -23,7 +12,7 @@ export interface Crew {
   participantCount: number;
 }
 
-export const getMyCrewList = async ({ size, page }: GetMyCrewListRequest): Promise<GetMyCrewListResponse> => {
+export const getMyCrewList = async ({ size, page }: GetMyCrewListRequest): Promise<Pagination<Crew>> => {
   const { data: response } = await privateClient.get('/crew/my', {
     params: {
       page: page,

--- a/src/features/crew/query/crewListQueries.ts
+++ b/src/features/crew/query/crewListQueries.ts
@@ -1,10 +1,11 @@
-import { getMyCrewList, GetMyCrewListRequest, GetMyCrewListResponse } from '../api/getMyCrewList';
+import { Pagination } from '@/shared/types/api';
+import { Crew, getMyCrewList, GetMyCrewListRequest } from '../api/getMyCrewList';
 import { queryOptions } from '@tanstack/react-query';
 
 export const crewListQueries = {
   myAllCrewKeys: ['myCrew'] as const,
   myCrewsPagination: ({ page, size }: GetMyCrewListRequest) =>
-    queryOptions<GetMyCrewListResponse>({
+    queryOptions<Pagination<Crew>>({
       queryKey: [...crewListQueries.myAllCrewKeys, 'list', page, size],
       queryFn: () => getMyCrewList({ page, size }),
     }),

--- a/src/features/member/api/getCrewMembers.ts
+++ b/src/features/member/api/getCrewMembers.ts
@@ -1,4 +1,5 @@
 import { privateClient } from '@/shared/api/config';
+import { Pagination } from '@/shared/types/api';
 
 export interface GetCrewMembersRequest {
   crewId: number;
@@ -6,19 +7,7 @@ export interface GetCrewMembersRequest {
   size: number;
 }
 
-export interface GetCrewMemberesResponse {
-  content: CrewMember[];
-  page: Page;
-}
-
-export interface Page {
-  size: number;
-  number: number;
-  totalPages: number;
-  totalElements: number;
-}
-
-interface CrewMember {
+export interface CrewMember {
   userId: number;
   name: string;
   role: 'LEADER' | 'MEMBER';
@@ -29,7 +18,7 @@ export const getCrewMembers = async ({
   crewId,
   page,
   size,
-}: GetCrewMembersRequest): Promise<GetCrewMemberesResponse> => {
+}: GetCrewMembersRequest): Promise<Pagination<CrewMember>> => {
   const { data: response } = await privateClient.get(`/crew/${crewId}/members`, {
     params: {
       page,

--- a/src/features/member/query/memberListQueries.ts
+++ b/src/features/member/query/memberListQueries.ts
@@ -1,10 +1,11 @@
 import { queryOptions } from '@tanstack/react-query';
-import { GetCrewMemberesResponse, getCrewMembers, GetCrewMembersRequest } from '../api/getCrewMembers';
+import { CrewMember, getCrewMembers, GetCrewMembersRequest } from '../api/getCrewMembers';
 import { crewMemberQueries } from '@/entities/member/query/memberQueries';
+import { Pagination } from '@/shared/types/api';
 
 export const memberListQueries = {
   crewMembersPagination: ({ page, size, crewId }: GetCrewMembersRequest) =>
-    queryOptions<GetCrewMemberesResponse>({
+    queryOptions<Pagination<CrewMember>>({
       queryKey: [...crewMemberQueries.allKeys, crewId, page, size],
       queryFn: () => getCrewMembers({ page, size, crewId }),
     }),

--- a/src/features/moment/api/getCrewMomentList.ts
+++ b/src/features/moment/api/getCrewMomentList.ts
@@ -1,0 +1,24 @@
+import { MomentJSONType } from '@/entities/moment/model/types';
+import { privateClient } from '@/shared/api/config';
+import { Pagination } from '@/shared/types/api';
+
+export interface GetCrewMomentListRequest {
+  crewId: number;
+  size: number;
+  page: number;
+}
+
+export const getCrewMomentList = async ({
+  crewId,
+  page,
+  size,
+}: GetCrewMomentListRequest): Promise<Pagination<MomentJSONType>> => {
+  const { data: response } = await privateClient.get(`/moment/crew/${crewId}`, {
+    params: {
+      page: page,
+      size: size,
+    },
+  });
+
+  return response.data;
+};

--- a/src/features/moment/hook/useCrewMomentListWithFile.ts
+++ b/src/features/moment/hook/useCrewMomentListWithFile.ts
@@ -1,0 +1,39 @@
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { momentListQueries } from '../query/momentListQueries';
+import { momentQueries } from '@/entities/moment/query/momentQueries';
+import { FileType } from '@/shared/types/api';
+
+// 모먼트와 이미지를 합병하는 커스텀 훅
+export const useCrewMomentListWithFile = (page: number, size: number, crewId: number) => {
+  const { data: momentListData } = useQuery({
+    ...momentListQueries.crewMomentPagination({ page, size, crewId }),
+  });
+
+  const fileQueries = useQueries({
+    queries: (momentListData?.content || []).map((crew) => ({
+      ...momentQueries.momentFile({ momentId: crew.momentId }),
+    })),
+  });
+
+  // 파일 데이터를 ID로 매핑
+  const fileDataMap: Record<number, FileType | undefined> = {};
+  momentListData?.content?.forEach((moment, index) => {
+    fileDataMap[moment.momentId] = fileQueries[index]?.data;
+  });
+
+  // 매핑을 사용하여 content 변환
+  const enhancedContent = momentListData?.content?.map((moment) => ({
+    ...moment,
+    file: fileDataMap[moment.momentId],
+  }));
+
+  // 변환된 데이터만 반환
+  return {
+    data: momentListData
+      ? {
+          ...momentListData,
+          content: enhancedContent || [],
+        }
+      : undefined,
+  };
+};

--- a/src/features/moment/query/momentListQueries.ts
+++ b/src/features/moment/query/momentListQueries.ts
@@ -1,0 +1,13 @@
+import { Pagination } from '@/shared/types/api';
+import { getCrewMomentList, GetCrewMomentListRequest } from '../api/getCrewMomentList';
+import { queryOptions } from '@tanstack/react-query';
+import { MomentJSONType } from '@/entities/moment/model/types';
+import { momentQueries } from '@/entities/moment/query/momentQueries';
+
+export const momentListQueries = {
+  crewMomentPagination: ({ page, size, crewId }: GetCrewMomentListRequest) =>
+    queryOptions<Pagination<MomentJSONType>>({
+      queryKey: [...momentQueries.allKeys, crewId, page, size],
+      queryFn: () => getCrewMomentList({ crewId, page, size }),
+    }),
+};

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,4 +1,5 @@
 export type FileEnvType = 'LOCAL' | 'CLOUD';
+
 export interface FileType {
   fileId: number;
   source: string;
@@ -20,4 +21,16 @@ interface Pageable {
   pageNumber: number;
   pageSize: number;
   paged: boolean;
+}
+
+export interface Pagination<T> {
+  content: T[];
+  page: Page;
+}
+
+interface Page {
+  size: number;
+  number: number;
+  totalPages: number;
+  totalElements: number;
 }

--- a/src/shared/ui/Badge/index.tsx
+++ b/src/shared/ui/Badge/index.tsx
@@ -2,17 +2,18 @@ import { IconType, TextColorType } from '@/shared/types/design-system';
 import styles from './index.module.scss';
 import { cn } from '@/shared/lib/cn';
 import Icon from '../Icon';
+import { PropsWithChildren } from 'react';
 
 type BadgeType = 'primary' | 'secondary' | 'tertiary';
 
-export interface BadgeProps {
+export interface BadgeProps extends PropsWithChildren {
   icon?: IconType;
   text?: string;
   variant?: BadgeType;
   className?: string;
 }
 
-function Badge({ icon, text, variant = 'primary', className }: BadgeProps) {
+function Badge({ icon, text, variant = 'primary', className, children }: BadgeProps) {
   const iconColorMap: Record<BadgeType, TextColorType> = {
     primary: 'text-default',
     secondary: 'text-default',
@@ -32,6 +33,7 @@ function Badge({ icon, text, variant = 'primary', className }: BadgeProps) {
     >
       {icon && <Icon icon={icon} iconSize="16" color={iconColorMap[variant]} />}
       {text && <span>{text}</span>}
+      {children}
     </span>
   );
 }

--- a/src/widgets/moment/CrewMomentList/index.tsx
+++ b/src/widgets/moment/CrewMomentList/index.tsx
@@ -1,135 +1,62 @@
-import { MomentType } from '@/entities/moment/model/types';
 import temp from '@/shared/assets/temp.jpg';
 import { usePagination } from '@/shared/hooks/usePagination';
 import { Card } from '@/shared/ui/Card';
 import GridContainer from '@/shared/ui/GridContainer';
 import Pagination from '@/shared/ui/Pagination';
 import styles from './index.module.scss';
-
-const data: MomentType[] = [
-  {
-    crewId: 1,
-    date: '2025.01.15 월요일 06:00',
-    endDate: '2025.02.20 월요일 06:00',
-    file: {
-      source: temp,
-      fileEnv: 'LOCAL',
-      fileId: 1,
-    },
-    location: '사당역 4번 출구',
-    name: '신년파티',
-    participantCount: 15,
-    capacity: 20,
-  },
-  {
-    crewId: 1,
-    date: '2025.01.15 월요일 06:00',
-    endDate: '2025.02.20 월요일 06:00',
-    file: {
-      source: temp,
-      fileEnv: 'LOCAL',
-      fileId: 1,
-    },
-    location: '사당역 4번 출구',
-    name: '신년파티',
-    participantCount: 15,
-    capacity: 20,
-  },
-  {
-    crewId: 1,
-    date: '2025.01.15 월요일 06:00',
-    endDate: '2025.02.20 월요일 06:00',
-    file: {
-      source: temp,
-      fileEnv: 'LOCAL',
-      fileId: 1,
-    },
-    location: '사당역 4번 출구',
-    name: '신년파티',
-    participantCount: 15,
-    capacity: 20,
-  },
-  {
-    crewId: 1,
-    date: '2025.01.15 월요일 06:00',
-    endDate: '2025.02.20 월요일 06:00',
-    file: {
-      source: temp,
-      fileEnv: 'LOCAL',
-      fileId: 1,
-    },
-    location: '사당역 4번 출구',
-    name: '신년파티',
-    participantCount: 15,
-    capacity: 20,
-  },
-  {
-    crewId: 1,
-    date: '2025.01.15 월요일 06:00',
-    endDate: '2025.02.20 월요일 06:00',
-    file: {
-      source: temp,
-      fileEnv: 'LOCAL',
-      fileId: 1,
-    },
-    location: '사당역 4번 출구',
-    name: '신년파티',
-    participantCount: 15,
-    capacity: 20,
-  },
-  {
-    crewId: 1,
-    date: '2025.01.15 월요일 06:00',
-    endDate: '2025.02.20 월요일 06:00',
-    file: {
-      source: temp,
-      fileEnv: 'LOCAL',
-      fileId: 1,
-    },
-    location: '사당역 4번 출구',
-    name: '신년파티',
-    participantCount: 15,
-    capacity: 20,
-  },
-  {
-    crewId: 1,
-    date: '2025.01.15 월요일 06:00',
-    endDate: '2025.02.20 월요일 06:00',
-    file: {
-      source: temp,
-      fileEnv: 'LOCAL',
-      fileId: 1,
-    },
-    location: '사당역 4번 출구',
-    name: '신년파티',
-    participantCount: 15,
-    capacity: 20,
-  },
-];
+import { useNavigate, useParams } from 'react-router-dom';
+import { useCrewMomentListWithFile } from '@/features/moment/hook/useCrewMomentListWithFile';
+import { useEffect } from 'react';
+import { routePaths } from '@/app/routes/path';
 
 function CrewMomentList() {
+  const { crewId } = useParams();
+  const navigate = useNavigate();
   const paginationTools = usePagination(1, 1, 7);
+  const { currentPage, setMaxPage } = paginationTools;
+  const { data: crewMomentListData } = useCrewMomentListWithFile(currentPage - 1, 12, Number(crewId));
+
+  useEffect(() => {
+    if (crewMomentListData?.page?.totalPages) setMaxPage(crewMomentListData.page.totalPages);
+  }, [crewMomentListData?.page?.totalPages, setMaxPage]);
+
+  const handleClickCard = (momentId: number) => {
+    navigate(routePaths.momentDetail.getPath(Number(crewId), momentId));
+  };
+
+  if (!crewMomentListData) return null;
+  const { content } = crewMomentListData;
+
+  const statusMap = {
+    참여중: 'primary',
+    참여가능: 'secondary',
+    마감: 'tertiary',
+  } as const;
+
   return (
     <>
       <GridContainer>
-        {data.map((moment) => {
+        {content.map((moment) => {
           return (
-            <Card key={moment.crewId} handleClick={() => {}}>
+            <Card key={moment.momentId} handleClick={() => handleClickCard(moment.momentId)}>
               <Card.Image src={moment.file?.source || temp} alt="크루 썸네일" />
+              <Card.Tag variant={statusMap[moment.status]}>{moment.status}</Card.Tag>
               <Card.Title>{moment.name}</Card.Title>
-              <Card.Detail>{moment.date}</Card.Detail>
-              <Card.Detail>{moment.location}</Card.Detail>
+              <Card.Detail>{moment.meetAt}</Card.Detail>
+              <Card.Detail>{moment.meetingPlaceName}</Card.Detail>
               <Card.Metadata>
                 참여 {moment.participantCount}/{moment.capacity}명
               </Card.Metadata>
-              <Card.Metadata>마감 {moment.endDate}</Card.Metadata>
+              <Card.Metadata>마감 {moment.closedAt}</Card.Metadata>
             </Card>
           );
         })}
       </GridContainer>
-      <div className={styles.pagination}>
-        <Pagination paginationTools={paginationTools} />
-      </div>
+      {crewMomentListData.page.totalPages > 0 && (
+        <div className={styles.pagination}>
+          <Pagination paginationTools={paginationTools} />
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## 🔥 PR 개요

<!-- PR의 목적을 간략히 설명해주세요. -->

- 크루별 모먼트 리스트 api 연동 

## 📌 주요 변경 사항

<!-- 변경된 내용을 상세히 적어주세요. -->

### 1. 모먼트 파일 관련 API 및 쿼리 구현
- 모먼트별 파일 조회 API 구현 (`getMomentFile`)

### 2. 크루별 모먼트 목록 조회 기능
- 크루별 모먼트 목록 조회 API 구현 (`getCrewMomentList`)
- 페이지네이션 처리를 포함한 쿼리 구현

### 3. 모먼트와 파일 데이터 연동 커스텀 훅
- 모먼트 목록과 파일 정보를 함께 제공하는 커스텀 훅 구현
- 병렬 쿼리를 통한 데이터 페칭 최적화
- 모먼트 ID 기반으로 파일 데이터 매핑 및 합성

### 4. 페이지네이션 인터페이스 공통화
- API 응답의 페이지네이션 데이터를 위한 공통 타입 정의
- 제네릭 인터페이스를 통한 다양한 엔티티 타입 지원
- 페이지 메타데이터 구조화

## 🔗 관련 이슈

- Closes #45 

## 🔍 테스트 방법

<!-- 변경된 기능을 테스트하는 방법을 설명해주세요. -->

1. `yarn dev` 실행
2. 로그인
3. 크루 생성
4. 크루의 모먼트 생성
5. 해당 크루의 모먼트 탭 이동 

## 📷 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

## 📢 리뷰 요구 사항 (선택)

<!-- 리뷰어에게 요구 사항이 있다면 적어주세요.. -->

## 📜 기타 참고 사항 (선택)

<!-- 추가적으로 참고할 사항이 있다면 적어주세요. -->


## ✅ 체크리스트

<!-- 아래 항목을 확인하고 `[x]`로 표시해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 관련 이슈를 Closes #이슈번호로 닫았나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 관련 문서를 업데이트했나요?
