### PR TITLE
[FEAT] 모먼트 상세보기 UI/api 연동 

### DIFF
--- a/src/app/routes/index.tsx
+++ b/src/app/routes/index.tsx
@@ -16,6 +16,7 @@ import MemberJoinPage from '@/pages/MemberJoinPage';
 import MomentCreatePage from '@/pages/MomentCreatePage';
 import FullLayout from '../layouts/FullLayout';
 import MomentPlacePage from '@/pages/MomentPlacePage';
+import MomentDetailPage from '@/pages/MomentDetailPage';
 
 export function Routing() {
   return (
@@ -33,6 +34,7 @@ export function Routing() {
           <Route path={routePaths.main} element={<Main />} />
           <Route path={routePaths.createCrew} element={<CrewCreatePage />} />
           <Route path={routePaths.momentCreate.path} element={<MomentCreatePage />} />
+          <Route path={routePaths.momentDetail.path} element={<MomentDetailPage />} />
         </Route>
 
         <Route element={<NavigationLayout />}>

--- a/src/entities/moment/api/getMoment.ts
+++ b/src/entities/moment/api/getMoment.ts
@@ -1,0 +1,28 @@
+import { Location } from '@/entities/Location/model/types';
+import { privateClient } from '@/shared/api/config';
+import { MomentJSONType } from '../model/types';
+
+export interface GetMomentRequest {
+  momentId: number;
+}
+
+export const getMoment = async ({ momentId }: GetMomentRequest): Promise<MomentJSONType> => {
+  const { data: response } = await privateClient.get(`/moment/${momentId}`);
+  const { place_name, id, x, y, address_name, road_address_name, place_url, phone } = response.data.place;
+
+  const formattedPlace: Location = {
+    placeName: place_name,
+    placeURL: place_url,
+    addressName: address_name,
+    roadAddressName: road_address_name,
+    phone: phone,
+    id: id,
+    x: x,
+    y: y,
+  };
+
+  return {
+    ...response.data,
+    place: formattedPlace,
+  };
+};

--- a/src/entities/moment/api/postMoment.ts
+++ b/src/entities/moment/api/postMoment.ts
@@ -24,8 +24,6 @@ export const postMoment = async ({ crewId, momentName, meetAt, place, capacity, 
     y: y,
   };
 
-  console.log(formattedPlace);
-
   const { data: response } = await privateClient.post(
     '/moment',
     {

--- a/src/entities/moment/model/types.ts
+++ b/src/entities/moment/model/types.ts
@@ -1,3 +1,4 @@
+import { Location } from '@/entities/Location/model/types';
 import { FileType } from '@/shared/types/api';
 
 export interface MomentJSONType {
@@ -9,6 +10,7 @@ export interface MomentJSONType {
   participantCount: number;
   capacity: number;
   closedAt: string;
+  place: Location;
 }
 
 export interface MomentType extends MomentJSONType {

--- a/src/entities/moment/query/momentQueries.ts
+++ b/src/entities/moment/query/momentQueries.ts
@@ -1,8 +1,15 @@
 import { queryOptions } from '@tanstack/react-query';
 import { getMomentFile, GetMomentFileRequest } from '../api/getMomentFile';
+import { getMoment, GetMomentRequest } from '../api/getMoment';
 
 export const momentQueries = {
   allKeys: ['crewMoment'] as const,
+
+  momentJSON: ({ momentId }: GetMomentRequest) =>
+    queryOptions({
+      queryKey: [...momentQueries.allKeys, 'json', momentId],
+      queryFn: () => getMoment({ momentId }),
+    }),
 
   momentFile: ({ momentId }: GetMomentFileRequest) =>
     queryOptions({

--- a/src/entities/moment/query/useMomentDetailWithFile.ts
+++ b/src/entities/moment/query/useMomentDetailWithFile.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { MomentType } from '../model/types';
+import { momentQueries } from './momentQueries';
+
+interface UseMomentDetailWithFileReturn {
+  data: MomentType | undefined;
+}
+
+// 모먼트와 이미지를 합병하는 커스텀 훅
+export const useMomentDetailWithFile = (momentId: number): UseMomentDetailWithFileReturn => {
+  const { data: momentData } = useQuery({
+    ...momentQueries.momentJSON({ momentId }),
+  });
+
+  const { data: fileData } = useQuery({
+    ...momentQueries.momentFile({ momentId }),
+    enabled: !!momentData,
+  });
+
+  return {
+    data: momentData
+      ? {
+          ...momentData,
+          file: fileData,
+        }
+      : undefined,
+  };
+};

--- a/src/entities/moment/ui/MomentDetailHeader/index.module.scss
+++ b/src/entities/moment/ui/MomentDetailHeader/index.module.scss
@@ -1,0 +1,18 @@
+@use '@/shared/styles/global.scss' as *;
+
+.container {
+  @include flex-row(between, center);
+  margin-bottom: $space-md;
+  gap: $space-md;
+}
+
+.title {
+  @include font-text(heading-large);
+  color: var(--text-primary);
+  @include util-text-overflow-ellipsis;
+}
+
+.buttons {
+  @include flex-row;
+  gap: $space-xs;
+}

--- a/src/entities/moment/ui/MomentDetailHeader/index.tsx
+++ b/src/entities/moment/ui/MomentDetailHeader/index.tsx
@@ -1,0 +1,16 @@
+import Button from '@/shared/ui/Button';
+import styles from './index.module.scss';
+
+function MomentDetailHeader() {
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>피자 탐방하기</h2>
+      <div className={styles.buttons}>
+        <Button variant="secondary" icon="people-stroke" text="3명" />
+        <Button>참여</Button>
+      </div>
+    </div>
+  );
+}
+
+export default MomentDetailHeader;

--- a/src/entities/moment/ui/MomentDetailHeader/index.tsx
+++ b/src/entities/moment/ui/MomentDetailHeader/index.tsx
@@ -1,10 +1,16 @@
 import Button from '@/shared/ui/Button';
 import styles from './index.module.scss';
+import { useMomentDetailWithFile } from '../../query/useMomentDetailWithFile';
+import { useParams } from 'react-router-dom';
 
 function MomentDetailHeader() {
+  const { momentId } = useParams();
+  const { data: momentDetail } = useMomentDetailWithFile(Number(momentId));
+
+  if (!momentDetail) return null;
   return (
     <div className={styles.container}>
-      <h2 className={styles.title}>피자 탐방하기</h2>
+      <h2 className={styles.title}>{momentDetail.name}</h2>
       <div className={styles.buttons}>
         <Button variant="secondary" icon="people-stroke" text="3명" />
         <Button>참여</Button>

--- a/src/entities/moment/ui/MomentInformation/index.module.scss
+++ b/src/entities/moment/ui/MomentInformation/index.module.scss
@@ -1,0 +1,50 @@
+@use '@/shared/styles/global' as *;
+
+.container {
+  display: flex;
+  gap: $space-md;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.thumbnail {
+  width: 100%;
+  max-width: 32rem;
+  aspect-ratio: 16/9;
+}
+
+.field-container {
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  gap: $space-md;
+  max-width: 32rem;
+}
+
+.field {
+  display: flex;
+  width: 100%;
+  gap: $space-md;
+}
+
+.field__title {
+  @include font-text(heading-small);
+  color: var(--text-primary);
+  min-width: 10rem;
+}
+
+.field__content {
+  display: flex;
+  flex-direction: column;
+  gap: $space-xs;
+}
+
+.field__main-content {
+  @include font-text(body-medium);
+  color: var(--text-primary);
+}
+
+.field__sub-content {
+  @include font-text(body-small);
+  color: var(--text-tertiary);
+}

--- a/src/entities/moment/ui/MomentInformation/index.tsx
+++ b/src/entities/moment/ui/MomentInformation/index.tsx
@@ -1,0 +1,39 @@
+import temp from '@/shared/assets/temp.jpg';
+import styles from './index.module.scss';
+
+function MomentInformation() {
+  return (
+    <div className={styles.container}>
+      <img className={styles.thumbnail} src={temp} alt="모먼트 썸네일" />
+      <div className={styles.fieldContainer}>
+        <div className={styles.field}>
+          <h3 className={styles.fieldTitle}>모먼트명</h3>
+          <p className={styles.fieldMainContent}>피자 탐방하기</p>
+        </div>
+        <div className={styles.field}>
+          <h3 className={styles.fieldTitle}>만나는 날짜</h3>
+          <p className={styles.fieldMainContent}>2025.01.29 화요일 10:00</p>
+        </div>
+        <div className={styles.field}>
+          <h3 className={styles.fieldTitle}>만나는 장소</h3>
+          <div className={styles.fieldContent}>
+            <p className={styles.fieldMainContent}>명동교자 이태원점</p>
+            <p className={styles.fieldSubContent}>도로명: 서울 용산구 녹사평대로 136</p>
+            <p className={styles.fieldSubContent}>지번: 서울 용산구 이태원동 34-149</p>{' '}
+            <p className={styles.fieldSubContent}>연락처: 02-790-7300</p>
+          </div>
+        </div>
+        <div className={styles.field}>
+          <h3 className={styles.fieldTitle}>참여/마감 인원</h3>
+          <p className={styles.fieldMainContent}>3/10명</p>
+        </div>
+        <div className={styles.field}>
+          <h3 className={styles.fieldTitle}>신청 마감 날짜</h3>
+          <p className={styles.fieldMainContent}>2025.01.29 화요일 10:00</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MomentInformation;

--- a/src/entities/moment/ui/MomentInformation/index.tsx
+++ b/src/entities/moment/ui/MomentInformation/index.tsx
@@ -1,35 +1,44 @@
 import temp from '@/shared/assets/temp.jpg';
 import styles from './index.module.scss';
+import { useMomentDetailWithFile } from '../../query/useMomentDetailWithFile';
+import { useParams } from 'react-router-dom';
 
 function MomentInformation() {
+  const { momentId } = useParams();
+  const { data: momentDetail } = useMomentDetailWithFile(Number(momentId));
+
+  if (!momentDetail) return null;
+
   return (
     <div className={styles.container}>
       <img className={styles.thumbnail} src={temp} alt="모먼트 썸네일" />
       <div className={styles.fieldContainer}>
         <div className={styles.field}>
           <h3 className={styles.fieldTitle}>모먼트명</h3>
-          <p className={styles.fieldMainContent}>피자 탐방하기</p>
+          <p className={styles.fieldMainContent}>{momentDetail.name}</p>
         </div>
         <div className={styles.field}>
           <h3 className={styles.fieldTitle}>만나는 날짜</h3>
-          <p className={styles.fieldMainContent}>2025.01.29 화요일 10:00</p>
+          <p className={styles.fieldMainContent}>{momentDetail.meetAt}</p>
         </div>
         <div className={styles.field}>
           <h3 className={styles.fieldTitle}>만나는 장소</h3>
           <div className={styles.fieldContent}>
-            <p className={styles.fieldMainContent}>명동교자 이태원점</p>
-            <p className={styles.fieldSubContent}>도로명: 서울 용산구 녹사평대로 136</p>
-            <p className={styles.fieldSubContent}>지번: 서울 용산구 이태원동 34-149</p>{' '}
-            <p className={styles.fieldSubContent}>연락처: 02-790-7300</p>
+            <p className={styles.fieldMainContent}>{momentDetail.place.placeName}</p>
+            <p className={styles.fieldSubContent}>도로명: {momentDetail.place.roadAddressName}</p>
+            <p className={styles.fieldSubContent}>지번: {momentDetail.place.addressName}</p>
+            <p className={styles.fieldSubContent}>연락처: {momentDetail.place.phone}</p>
           </div>
         </div>
         <div className={styles.field}>
           <h3 className={styles.fieldTitle}>참여/마감 인원</h3>
-          <p className={styles.fieldMainContent}>3/10명</p>
+          <p className={styles.fieldMainContent}>
+            {momentDetail.participantCount}/{momentDetail.capacity}명
+          </p>
         </div>
         <div className={styles.field}>
           <h3 className={styles.fieldTitle}>신청 마감 날짜</h3>
-          <p className={styles.fieldMainContent}>2025.01.29 화요일 10:00</p>
+          <p className={styles.fieldMainContent}>{momentDetail.closedAt}</p>
         </div>
       </div>
     </div>

--- a/src/entities/moment/ui/MomentInformationHeader/index.module.scss
+++ b/src/entities/moment/ui/MomentInformationHeader/index.module.scss
@@ -1,0 +1,13 @@
+@use '@/shared/styles/global.scss' as *;
+
+.container {
+  @include flex-row(between, center);
+  margin-bottom: $space-md;
+  gap: $space-md;
+}
+
+.title {
+  @include font-text(heading-medium);
+  color: var(--text-primary);
+  @include util-text-overflow-ellipsis;
+}

--- a/src/entities/moment/ui/MomentInformationHeader/index.tsx
+++ b/src/entities/moment/ui/MomentInformationHeader/index.tsx
@@ -1,0 +1,13 @@
+import Button from '@/shared/ui/Button';
+import styles from './index.module.scss';
+
+function MomentInformationHeader() {
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>모먼트 정보</h2>
+      <Button variant="secondary">수정</Button>
+    </div>
+  );
+}
+
+export default MomentInformationHeader;

--- a/src/entities/moment/ui/MomentPlaceHeader/index.module.scss
+++ b/src/entities/moment/ui/MomentPlaceHeader/index.module.scss
@@ -1,0 +1,13 @@
+@use '@/shared/styles/global' as *;
+
+.container {
+  @include flex-row(between, center);
+  margin-bottom: $space-md;
+  gap: $space-md;
+}
+
+.title {
+  @include font-text(heading-medium);
+  color: var(--text-primary);
+  @include util-text-overflow-ellipsis;
+}

--- a/src/entities/moment/ui/MomentPlaceHeader/index.tsx
+++ b/src/entities/moment/ui/MomentPlaceHeader/index.tsx
@@ -1,0 +1,13 @@
+import Button from '@/shared/ui/Button';
+import styles from './index.module.scss';
+
+function MomentPlaceHeader() {
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>방문 장소</h2>
+      <Button variant="secondary">더보기</Button>
+    </div>
+  );
+}
+
+export default MomentPlaceHeader;

--- a/src/features/Location/api/getSearchLocation.ts
+++ b/src/features/Location/api/getSearchLocation.ts
@@ -19,8 +19,6 @@ export const getSearchLocation = async ({
     params: { keyword, page, size },
   });
 
-  console.log(response.data);
-
   const { content, ...rest }: GetSarchLocationResponse = response.data;
   const clientContent: Location[] = content.map((item: LocationAboutServer) => ({
     id: item.id,

--- a/src/features/moment/api/getMomentPlaces.ts
+++ b/src/features/moment/api/getMomentPlaces.ts
@@ -1,0 +1,43 @@
+import { privateClient } from '@/shared/api/config';
+import { MomentPlace, MomentPlaces } from '../model/types';
+
+export interface GetMomentPlacesRequest {
+  momentId: number;
+}
+
+interface LocationInfoResponse {
+  index: number;
+  placeId: number;
+  name: string;
+  address: string;
+  roadAddress: string;
+  url: string;
+  x: number;
+  y: number;
+  phone: string;
+}
+
+export const getMomentPlaces = async ({ momentId }: GetMomentPlacesRequest): Promise<MomentPlaces> => {
+  const { data: response } = await privateClient.get(`/location/${momentId}`);
+  const { locationInfos, ...rest } = response.data;
+
+  const formattedLocationInfos = locationInfos.map((info: LocationInfoResponse): MomentPlace => {
+    const { index, placeId, name, address, roadAddress, url, x, y, phone } = info;
+    return {
+      id: placeId,
+      placeName: name,
+      placeURL: url,
+      addressName: address,
+      roadAddressName: roadAddress,
+      phone,
+      index,
+      x,
+      y,
+    };
+  });
+
+  return {
+    ...rest,
+    places: formattedLocationInfos,
+  };
+};

--- a/src/features/moment/hook/useCrewMomentListWithFile.ts
+++ b/src/features/moment/hook/useCrewMomentListWithFile.ts
@@ -1,12 +1,12 @@
 import { useQueries, useQuery } from '@tanstack/react-query';
-import { momentListQueries } from '../query/momentListQueries';
+import { momentFeatureQueries } from '../query/momentFeatureQueries';
 import { momentQueries } from '@/entities/moment/query/momentQueries';
 import { FileType } from '@/shared/types/api';
 
 // 모먼트와 이미지를 합병하는 커스텀 훅
 export const useCrewMomentListWithFile = (page: number, size: number, crewId: number) => {
   const { data: momentListData } = useQuery({
-    ...momentListQueries.crewMomentPagination({ page, size, crewId }),
+    ...momentFeatureQueries.crewMomentPagination({ page, size, crewId }),
   });
 
   const fileQueries = useQueries({

--- a/src/features/moment/model/types.ts
+++ b/src/features/moment/model/types.ts
@@ -8,3 +8,13 @@ export interface MomentFormType {
   closedAt: string;
   place: Location | undefined;
 }
+
+export interface MomentPlace extends Location {
+  index: number;
+}
+
+export interface MomentPlaces {
+  momentId: number;
+  places: MomentPlace[];
+  count: number;
+}

--- a/src/features/moment/query/momentFeatureQueries.ts
+++ b/src/features/moment/query/momentFeatureQueries.ts
@@ -3,11 +3,18 @@ import { getCrewMomentList, GetCrewMomentListRequest } from '../api/getCrewMomen
 import { queryOptions } from '@tanstack/react-query';
 import { MomentJSONType } from '@/entities/moment/model/types';
 import { momentQueries } from '@/entities/moment/query/momentQueries';
+import { getMomentPlaces, GetMomentPlacesRequest } from '../api/getMomentPlaces';
 
-export const momentListQueries = {
+export const momentFeatureQueries = {
   crewMomentPagination: ({ page, size, crewId }: GetCrewMomentListRequest) =>
     queryOptions<Pagination<MomentJSONType>>({
       queryKey: [...momentQueries.allKeys, crewId, page, size],
       queryFn: () => getCrewMomentList({ crewId, page, size }),
+    }),
+
+  momentPlaces: ({ momentId }: GetMomentPlacesRequest) =>
+    queryOptions({
+      queryKey: [...momentQueries.allKeys, momentId],
+      queryFn: () => getMomentPlaces({ momentId }),
     }),
 };

--- a/src/features/moment/ui/MomentPlaceRow/index.tsx
+++ b/src/features/moment/ui/MomentPlaceRow/index.tsx
@@ -1,0 +1,29 @@
+import ScrollableRow from '@/shared/ui/ScrollableRow';
+import { useQuery } from '@tanstack/react-query';
+import { momentFeatureQueries } from '../../query/momentFeatureQueries';
+import { useParams } from 'react-router-dom';
+import { Card } from '@/shared/ui/Card';
+
+function MomentPlaceRow() {
+  const { momentId } = useParams();
+  const { data } = useQuery({ ...momentFeatureQueries.momentPlaces({ momentId: Number(momentId) }) });
+
+  if (!data) return null;
+
+  return (
+    <ScrollableRow>
+      {data.places.map((place) => (
+        <Card key={place.id} size="md" border={true} handleClick={() => {}}>
+          <Card.Text>
+            <Card.Detail>{place.placeName}</Card.Detail>
+            <Card.Metadata>도로명: {place.roadAddressName}</Card.Metadata>
+            <Card.Metadata>지번: {place.addressName}</Card.Metadata>
+            <Card.Metadata>연락처: {place.phone}</Card.Metadata>
+          </Card.Text>
+        </Card>
+      ))}
+    </ScrollableRow>
+  );
+}
+
+export default MomentPlaceRow;

--- a/src/pages/MomentCreatePage/index.tsx
+++ b/src/pages/MomentCreatePage/index.tsx
@@ -45,7 +45,7 @@ function MomentCreatePage() {
     });
 
     await postMomentFile({ momentId, files: files });
-    navigate(routePaths.momentPlace.getPath(Number(crewId), momentId));
+    navigate(routePaths.momentDetail.getPath(Number(crewId), momentId));
   };
 
   if (!crewData) return null;

--- a/src/pages/MomentDetailPage/index.module.scss
+++ b/src/pages/MomentDetailPage/index.module.scss
@@ -3,5 +3,5 @@
 .container {
   display: flex;
   flex-direction: column;
-  gap: $space-md;
+  gap: $space-xl;
 }

--- a/src/pages/MomentDetailPage/index.module.scss
+++ b/src/pages/MomentDetailPage/index.module.scss
@@ -1,0 +1,7 @@
+@use '@/shared/styles/global.scss' as *;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: $space-md;
+}

--- a/src/pages/MomentDetailPage/index.tsx
+++ b/src/pages/MomentDetailPage/index.tsx
@@ -1,14 +1,23 @@
 import MomentDetailHeader from '@/entities/moment/ui/MomentDetailHeader';
 import MomentInformation from '@/entities/moment/ui/MomentInformation';
 import MomentInformationHeader from '@/entities/moment/ui/MomentInformationHeader';
+import MomentPlaceHeader from '@/entities/moment/ui/MomentPlaceHeader';
+import MomentPlaceRow from '@/features/moment/ui/MomentPlaceRow';
+import styles from './index.module.scss';
 
 function MomentDetailPage() {
   return (
-    <>
+    <main className={styles.container}>
       <MomentDetailHeader />
-      <MomentInformationHeader />
-      <MomentInformation />
-    </>
+      <div>
+        <MomentInformationHeader />
+        <MomentInformation />
+      </div>
+      <div>
+        <MomentPlaceHeader />
+        <MomentPlaceRow />
+      </div>
+    </main>
   );
 }
 

--- a/src/pages/MomentDetailPage/index.tsx
+++ b/src/pages/MomentDetailPage/index.tsx
@@ -1,0 +1,15 @@
+import MomentDetailHeader from '@/entities/moment/ui/MomentDetailHeader';
+import MomentInformation from '@/entities/moment/ui/MomentInformation';
+import MomentInformationHeader from '@/entities/moment/ui/MomentInformationHeader';
+
+function MomentDetailPage() {
+  return (
+    <>
+      <MomentDetailHeader />
+      <MomentInformationHeader />
+      <MomentInformation />
+    </>
+  );
+}
+
+export default MomentDetailPage;

--- a/src/shared/ui/Button/index.module.scss
+++ b/src/shared/ui/Button/index.module.scss
@@ -13,7 +13,7 @@
   justify-content: center;
   align-items: center;
   padding: $space-xs;
-  gap: $space-xs;
+  gap: $space-xxs;
 }
 
 .primary-button {

--- a/src/shared/ui/Card/index.module.scss
+++ b/src/shared/ui/Card/index.module.scss
@@ -17,6 +17,11 @@
   }
 }
 
+.wrapper--border {
+  border: 1px solid var(--border-default);
+  border-radius: 0.8rem;
+}
+
 .tag {
   position: absolute;
   top: $space-xs;

--- a/src/shared/ui/Card/index.tsx
+++ b/src/shared/ui/Card/index.tsx
@@ -9,29 +9,14 @@ interface CardImageProps {
   alt: string;
 }
 
-const ImageComponent = (<CardImage src="" alt="" />).type;
-const TitleComponent = (<CardTitle />).type;
-const DetailComponent = (<CardDetail />).type;
-const MetadataComponent = (<CardMetadata />).type;
-const BadgeComponent = (<CardTag />).type;
-
 interface MainProps extends PropsWithChildren {
   size?: 'full' | 'md';
   classNames?: string;
   handleClick: () => void;
+  border?: boolean;
 }
 
-function Main({ children, size = 'full', classNames, handleClick }: MainProps) {
-  const imageElements = filterChildrenByComponent(children, ImageComponent);
-  const titleElements = filterChildrenByComponent(children, TitleComponent);
-  const detailElements = filterChildrenByComponent(children, DetailComponent);
-  const metadataElements = filterChildrenByComponent(children, MetadataComponent);
-  const badgeElements = filterChildrenByComponent(children, BadgeComponent);
-
-  const hasContent = titleElements.length > 0 || detailElements.length > 0 || metadataElements.length > 0;
-  const hasDetailElement = detailElements.length > 0;
-  const hasMetadataElement = metadataElements.length > 0;
-
+function Main({ children, size = 'full', classNames, handleClick, border }: MainProps) {
   return (
     <article>
       <button
@@ -41,19 +26,12 @@ function Main({ children, size = 'full', classNames, handleClick }: MainProps) {
           {
             [styles.fullCard]: size === 'full',
             [styles.mdCard]: size === 'md',
+            [styles.wrapperBorder]: border === true,
           },
           classNames,
         )}
       >
-        {imageElements}
-        {badgeElements}
-        {hasContent && (
-          <div className={styles.content}>
-            {titleElements}
-            {hasDetailElement && <div className={styles.detailContainer}>{detailElements}</div>}
-            {hasMetadataElement && <div className={styles.metaContainer}>{metadataElements}</div>}
-          </div>
-        )}
+        {children}
       </button>
     </article>
   );
@@ -63,6 +41,23 @@ function CardImage({ src, alt }: CardImageProps) {
   return (
     <div className={styles.imageContainer}>
       <img src={src} className={styles.image} alt={alt} />
+    </div>
+  );
+}
+
+function CardText({ children }: PropsWithChildren) {
+  const titleElements = filterChildrenByComponent(children, CardTitle);
+  const detailElements = filterChildrenByComponent(children, CardDetail);
+  const metadataElements = filterChildrenByComponent(children, CardMetadata);
+
+  const hasDetailElement = detailElements.length > 0;
+  const hasMetadataElement = metadataElements.length > 0;
+
+  return (
+    <div className={styles.content}>
+      {titleElements}
+      {hasDetailElement && <div className={styles.detailContainer}>{detailElements}</div>}
+      {hasMetadataElement && <div className={styles.metaContainer}>{metadataElements}</div>}
     </div>
   );
 }
@@ -86,6 +81,7 @@ function CardTag({ ...props }: BadgeProps) {
 export const Card = Object.assign(Main, {
   Tag: CardTag,
   Image: CardImage,
+  Text: CardText,
   Title: CardTitle,
   Detail: CardDetail,
   Metadata: CardMetadata,

--- a/src/widgets/crew/ParticipatingCrewList/index.tsx
+++ b/src/widgets/crew/ParticipatingCrewList/index.tsx
@@ -32,8 +32,10 @@ function ParticipatingCrewList() {
           return (
             <Card key={crew.crewId} handleClick={() => handleClickCard(crew.crewId)}>
               <Card.Image src={crew.file?.source || temp} alt="크루 썸네일" />
-              <Card.Title>{crew.name}</Card.Title>
-              <Card.Detail>크루원 {crew.participantCount}</Card.Detail>
+              <Card.Text>
+                <Card.Title>{crew.name}</Card.Title>
+                <Card.Detail>크루원 {crew.participantCount}</Card.Detail>
+              </Card.Text>
             </Card>
           );
         })}

--- a/src/widgets/moment/CrewMomentList/index.tsx
+++ b/src/widgets/moment/CrewMomentList/index.tsx
@@ -41,13 +41,15 @@ function CrewMomentList() {
             <Card key={moment.momentId} handleClick={() => handleClickCard(moment.momentId)}>
               <Card.Image src={moment.file?.source || temp} alt="크루 썸네일" />
               <Card.Tag variant={statusMap[moment.status]}>{moment.status}</Card.Tag>
-              <Card.Title>{moment.name}</Card.Title>
-              <Card.Detail>{moment.meetAt}</Card.Detail>
-              <Card.Detail>{moment.meetingPlaceName}</Card.Detail>
-              <Card.Metadata>
-                참여 {moment.participantCount}/{moment.capacity}명
-              </Card.Metadata>
-              <Card.Metadata>마감 {moment.closedAt}</Card.Metadata>
+              <Card.Text>
+                <Card.Title>{moment.name}</Card.Title>
+                <Card.Detail>{moment.meetAt}</Card.Detail>
+                <Card.Detail>{moment.meetingPlaceName}</Card.Detail>
+                <Card.Metadata>
+                  참여 {moment.participantCount}/{moment.capacity}명
+                </Card.Metadata>
+                <Card.Metadata>마감 {moment.closedAt}</Card.Metadata>
+              </Card.Text>
             </Card>
           );
         })}

--- a/src/widgets/moment/UpcomingMomentList/index.tsx
+++ b/src/widgets/moment/UpcomingMomentList/index.tsx
@@ -112,10 +112,12 @@ function UpcomingMomentList() {
           <Card key={data.id} size="md" handleClick={() => {}}>
             <Card.Image src={image} alt="크루 썸네일" />
             <Card.Tag variant="tertiary" text={`D-${getDDayNumber(data.date)}`}></Card.Tag>
-            <Card.Title>{data.crew}</Card.Title>
-            <Card.Detail>{data.name}</Card.Detail>
-            <Card.Detail>{data.date}</Card.Detail>
-            <Card.Detail>{data.place}</Card.Detail>
+            <Card.Text>
+              <Card.Title>{data.crew}</Card.Title>
+              <Card.Detail>{data.name}</Card.Detail>
+              <Card.Detail>{data.date}</Card.Detail>
+              <Card.Detail>{data.place}</Card.Detail>
+            </Card.Text>
           </Card>
         );
       })}


### PR DESCRIPTION
## 🔥 PR 개요

<!-- PR의 목적을 간략히 설명해주세요. -->

- 모먼트 상세보기 UI/api 연동 

## 📌 주요 변경 사항

<!-- 변경된 내용을 상세히 적어주세요. -->

### 모먼트 상세 페이지 UI
- 모먼트 정보 섹션 구현 (썸네일, 모먼트명, 날짜, 장소, 인원, 마감일)
- 반응형 레이아웃 설정 (flex-wrap 활용)

### API 연동
- 모먼트 상세 정보 API 연동 및 데이터 처리
- 모먼트 데이터와 이미지 파일을 합치는 커스텀 훅 구현 (`useMomentDetailWithFile`)
- 특정 모먼트에 속한 장소들을 조회하는 API 연동

### 모먼트 장소 표시 기능
- 모먼트 장소 목록을 수평 스크롤 형태로 표시하는 컴포넌트 구현

## 🔗 관련 이슈

- Closes #58 

## 🔍 테스트 방법

<!-- 변경된 기능을 테스트하는 방법을 설명해주세요. -->

1. `yarn dev` 실행
2. 로그인
3. 크루 생성
4. 모먼트 생성 

## 📷 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

![5](https://github.com/user-attachments/assets/dc08c5d2-a375-4c57-9f5e-abe7cbce6bf6)


## 📢 리뷰 요구 사항 (선택)

<!-- 리뷰어에게 요구 사항이 있다면 적어주세요.. -->

## 📜 기타 참고 사항 (선택)

<!-- 추가적으로 참고할 사항이 있다면 적어주세요. -->


## ✅ 체크리스트

<!-- 아래 항목을 확인하고 `[x]`로 표시해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 관련 이슈를 Closes #이슈번호로 닫았나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 관련 문서를 업데이트했나요?
