### PR TITLE
[FEAT] 방문 장소 순서 변경 api 연동 

### DIFF
--- a/src/features/moment/api/patchMomentPlace.ts
+++ b/src/features/moment/api/patchMomentPlace.ts
@@ -1,0 +1,14 @@
+import { privateClient } from '@/shared/api/config';
+
+interface PatchMomentPlaceRequest {
+  momentId: number;
+  originalIndex: number;
+  newIndex: number;
+}
+
+export const patchMomentPlace = async ({ momentId, originalIndex, newIndex }: PatchMomentPlaceRequest) => {
+  await privateClient.patch(`/location/${momentId}`, {
+    originalIndex,
+    newIndex,
+  });
+};

--- a/src/features/moment/query/usePatchMomentPlace.ts
+++ b/src/features/moment/query/usePatchMomentPlace.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { momentFeatureQueries } from './momentFeatureQueries';
+import { patchMomentPlace } from '../api/patchMomentPlace';
+
+export const usePatchMomentPlace = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchMomentPlace,
+    onSuccess: async (_, variables) => {
+      const momentPlaceKey = momentFeatureQueries.momentPlaces({ momentId: variables.momentId }).queryKey;
+      await queryClient.invalidateQueries({ queryKey: momentPlaceKey });
+    },
+  });
+};


### PR DESCRIPTION
## 🔥 PR 개요

<!-- PR의 목적을 간략히 설명해주세요. -->

- 방문 장소 순서 변경 api 연동 

## 📌 주요 변경 사항

<!-- 변경된 내용을 상세히 적어주세요. -->

- 드래그 앤 드롭으로 순서가 변경되면 API를 호출 
- React Query의 useMutation 훅을 활용하여 API 호출 및 데이터 상태 관리 
- 순서 변경이 없는 경우(동일한 위치에 놓을 때) 불필요한 API 호출을 방지

## 🔗 관련 이슈

- Closes #70 

## 🔍 테스트 방법

<!-- 변경된 기능을 테스트하는 방법을 설명해주세요. -->

1. `yarn dev` 실행
2. 로그인 
3. 크루 생성
4. 모먼트 생성
5. 방문장소 더보기 클릭
6. 방문 장소 추가 
7. 방문 장소 순서 변경 

## 📷 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

## 📢 리뷰 요구 사항 (선택)

<!-- 리뷰어에게 요구 사항이 있다면 적어주세요.. -->

## 📜 기타 참고 사항 (선택)

<!-- 추가적으로 참고할 사항이 있다면 적어주세요. -->


## ✅ 체크리스트

<!-- 아래 항목을 확인하고 `[x]`로 표시해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 관련 이슈를 Closes #이슈번호로 닫았나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 관련 문서를 업데이트했나요?
