### PR TITLE
[FEAT] 모먼트 참여자 목록 UI 구현

### DIFF
--- a/src/features/moment/ui/MomentDetailHeader/index.tsx
+++ b/src/features/moment/ui/MomentDetailHeader/index.tsx
@@ -4,12 +4,15 @@ import { useParams } from 'react-router-dom';
 import { useMomentDetailWithFile } from '@/entities/moment/query/useMomentDetailWithFile';
 import { usePostMomentJoin } from '../../query/usePostmomentJoin';
 import { useDeleteMomentJoin } from '../../query/useDeleteMomentJoin';
+import { useModal } from '@/shared/hooks/useModal';
+import MomentParticipantsModal from '../MomentParticipantsModal';
 
 function MomentDetailHeader() {
   const { momentId } = useParams();
   const { data: momentDetail } = useMomentDetailWithFile(Number(momentId));
   const { mutateAsync: joinMoment } = usePostMomentJoin();
   const { mutateAsync: cancelMomentJoin } = useDeleteMomentJoin();
+  const { isOpen, closeModal, openModal } = useModal();
 
   if (!momentDetail) return null;
 
@@ -54,15 +57,24 @@ function MomentDetailHeader() {
   const buttonProps = getButtonProps(momentDetail.isJoined, momentDetail.isClosed);
 
   return (
-    <div className={styles.container}>
-      <h2 className={styles.title}>{momentDetail.name}</h2>
-      <div className={styles.buttons}>
-        <Button variant="secondary" icon="people-stroke" text={`${momentDetail.participantCount}명`} />
-        <Button variant={buttonProps.variant} onClick={buttonProps?.onClick} disabled={buttonProps?.disabled}>
-          {buttonProps?.text}
-        </Button>
+    <>
+      <MomentParticipantsModal isOpen={isOpen} closeModal={closeModal} />
+
+      <div className={styles.container}>
+        <h2 className={styles.title}>{momentDetail.name}</h2>
+        <div className={styles.buttons}>
+          <Button
+            variant="secondary"
+            icon="people-stroke"
+            onClick={openModal}
+            text={`${momentDetail.participantCount}명`}
+          />
+          <Button variant={buttonProps.variant} onClick={buttonProps?.onClick} disabled={buttonProps?.disabled}>
+            {buttonProps?.text}
+          </Button>
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/features/moment/ui/MomentParticipantsModal/index.module.scss
+++ b/src/features/moment/ui/MomentParticipantsModal/index.module.scss
@@ -1,0 +1,15 @@
+@use '@/shared/styles/global' as *;
+
+.participant-list {
+  display: flex;
+  flex-direction: column;
+  gap: $space-xs;
+  max-height: 24rem;
+  overflow: auto;
+}
+
+.participnat-item {
+  display: flex;
+  align-items: center;
+  gap: $space-xs;
+}

--- a/src/features/moment/ui/MomentParticipantsModal/index.tsx
+++ b/src/features/moment/ui/MomentParticipantsModal/index.tsx
@@ -1,0 +1,42 @@
+import { Modal } from '@/shared/ui/Modal';
+import temp from '@/shared/assets/temp.jpg';
+import ProfileImage from '@/entities/user/ui/ProfileImage';
+import { ProfileNickname } from '@/entities/user/ui/ProfileNickname';
+import styles from './index.module.scss';
+interface MomentParticipantsModalProps {
+  isOpen: boolean;
+  closeModal: () => void;
+}
+
+const mock = [
+  {
+    nickname: 'test1',
+    image: temp,
+  },
+  {
+    nickname: 'test2',
+    image: temp,
+  },
+];
+
+function MomentParticipantsModal({ isOpen, closeModal }: MomentParticipantsModalProps) {
+  return (
+    <Modal isOpen={isOpen}>
+      <Modal.Overlay handleClick={closeModal} />
+      <Modal.Title>참여자 목록</Modal.Title>
+      <Modal.Content>
+        <ul className={styles.participantList}>
+          {mock.map((item, index) => (
+            <li key={index} className={styles.participnatItem}>
+              <ProfileImage size="medium" src={item.image} alt="프로필 이미지" />
+              <ProfileNickname size="md">{item.nickname}</ProfileNickname>
+            </li>
+          ))}
+        </ul>
+      </Modal.Content>
+      <Modal.RightButton onClick={closeModal}>확인</Modal.RightButton>
+    </Modal>
+  );
+}
+
+export default MomentParticipantsModal;


### PR DESCRIPTION
## 🔥 PR 개요

<!-- PR의 목적을 간략히 설명해주세요. -->

- 모먼트 참여자 목록 UI 구현

## 📌 주요 변경 사항

<!-- 변경된 내용을 상세히 적어주세요. -->

- MomentParticipantsModal 컴포넌트 추가
  - Modal 컴포넌트를 기반으로 구조 구성
  - ProfileImage, ProfileNickname UI 컴포넌트 사용

## 🔗 관련 이슈

- Closes #61 

## 🔍 테스트 방법

<!-- 변경된 기능을 테스트하는 방법을 설명해주세요. -->

1. `yarn dev` 실행
2. 로그인 
3. 크루 생성
4. 모먼트 생성
5. 모먼트 참여
6. 참여자 보기 

## 📷 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

![image](https://github.com/user-attachments/assets/e7b5f806-8df1-4440-8081-a8857820e036)


## 📢 리뷰 요구 사항 (선택)

<!-- 리뷰어에게 요구 사항이 있다면 적어주세요.. -->

## 📜 기타 참고 사항 (선택)

<!-- 추가적으로 참고할 사항이 있다면 적어주세요. -->

## ✅ 체크리스트

<!-- 아래 항목을 확인하고 `[x]`로 표시해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 관련 이슈를 Closes #이슈번호로 닫았나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 관련 문서를 업데이트했나요?
