### PR TITLE
[FEAT] 모먼트 참여자 목록 api 연동 

### DIFF
--- a/src/app/layouts/Header/index.tsx
+++ b/src/app/layouts/Header/index.tsx
@@ -1,7 +1,5 @@
 import Logo from '@/shared/ui/Logo';
 import styles from './index.module.scss';
-import ProfileImage from '@/entities/user/ui/ProfileImage';
-import fallbackSource from '@/shared/assets/basic-profile-image-gray.png';
 import Icon from '@/shared/ui/Icon';
 import { useContext } from 'react';
 import { ThemeContext } from '@/shared/contexts/ThemeContext';
@@ -16,9 +14,9 @@ function Header() {
         <button onClick={themeContext?.toggleTheme} className={styles.themeButton}>
           임시 테마 버튼
         </button>
-        <button>
+        {/*         <button>
           <ProfileImage size="small" src={fallbackSource} />
-        </button>
+        </button> */}
         <button>
           <Icon iconSize="28" icon="alarm" color="text-secondary" />
         </button>

--- a/src/entities/user/model/types.ts
+++ b/src/entities/user/model/types.ts
@@ -2,3 +2,8 @@ export interface UserInfoType {
   image: FileList;
   nickname: string;
 }
+
+export interface UserJson {
+  name: string;
+  userId: number;
+}

--- a/src/entities/user/ui/ProfileImage/index.tsx
+++ b/src/entities/user/ui/ProfileImage/index.tsx
@@ -1,15 +1,19 @@
 import { cn } from '@/shared/lib/cn.ts';
 import styles from './index.module.scss';
+import { useQuery } from '@tanstack/react-query';
+import { userQueries } from '../../query/userQueries';
 
 export interface ProfileImageProps {
   size: 'small' | 'medium' | 'large';
-  src?: string;
   alt?: string;
   className?: string;
+  userId: number;
 }
 
-function ProfileImage({ size, src, alt = '프로필 사진', className }: ProfileImageProps) {
-  return <img src={src} alt={alt} className={cn(styles.image, styles[`${size}-image`], className)} />;
+function ProfileImage({ size, alt = '프로필 사진', className, userId }: ProfileImageProps) {
+  const { data } = useQuery({ ...userQueries.profileFile({ userId }) });
+
+  return <img src={data?.source} alt={alt} className={cn(styles.image, styles[`${size}-image`], className)} />;
 }
 
 export default ProfileImage;

--- a/src/features/Location/ui/LocationSearchForm/index.module.scss
+++ b/src/features/Location/ui/LocationSearchForm/index.module.scss
@@ -4,11 +4,10 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow-y: hidden;
 }
 
 .search-result {
-  overflow-y: auto;
+  overflow: auto;
 }
 
 .underline {

--- a/src/features/Location/ui/LocationSearchForm/index.tsx
+++ b/src/features/Location/ui/LocationSearchForm/index.tsx
@@ -14,18 +14,16 @@ export interface LocationSearchFormProps {
 
 function LocationSearchForm({ keyword, handleSubmitKeyword, children }: LocationSearchFormProps) {
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const searchResultRef = useRef<HTMLDivElement>(null);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     ...locationListQueries.searchLocationWithInfiniteScroll({ page: 0, size: 15, keyword: keyword }),
     enabled: keyword.trim().length > 0,
   });
 
-  const observerRef = useInfiniteScroll({
+  const { rootRef, targetRef } = useInfiniteScroll({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-    root: searchResultRef.current,
   });
 
   const handleSearchLocation = (e: FormEvent<HTMLFormElement>) => {
@@ -49,7 +47,7 @@ function LocationSearchForm({ keyword, handleSubmitKeyword, children }: Location
         </TextInput>
       </form>
 
-      <div className={styles.searchResult} ref={searchResultRef}>
+      <div className={styles.searchResult} ref={rootRef}>
         {data &&
           data.pages.map((page) =>
             page.content.map((location) => {
@@ -62,7 +60,7 @@ function LocationSearchForm({ keyword, handleSubmitKeyword, children }: Location
             }),
           )}
 
-        <div style={{ height: '1px' }} ref={observerRef} />
+        <div style={{ height: '1px' }} ref={targetRef} />
       </div>
     </div>
   );

--- a/src/features/Location/ui/LocationSelectModal/index.module.scss
+++ b/src/features/Location/ui/LocationSelectModal/index.module.scss
@@ -1,0 +1,4 @@
+.modal__content {
+  height: 32rem;
+  overflow: auto;
+}

--- a/src/features/Location/ui/LocationSelectModal/index.tsx
+++ b/src/features/Location/ui/LocationSelectModal/index.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Location } from '@/entities/Location/model/types';
 import LocationSearchForm from '../LocationSearchForm';
 import { Card } from '@/shared/ui/Card';
-
+import styles from './index.module.scss';
 export interface LocationSelectModalProps {
   isOpen: boolean;
   closeModal: () => void;
@@ -26,23 +26,25 @@ function LocationSelectModal({ isOpen, closeModal, handleSelectLocation }: Locat
       <Modal.Overlay handleClick={handleCloseModal} />
       <Modal.Title>장소 검색하기</Modal.Title>
       <Modal.Content>
-        <LocationSearchForm keyword={keyword} handleSubmitKeyword={handleSubmitKeyword}>
-          {(location) => {
-            const { id, placeName, roadAddressName, addressName, phone } = location;
-            return (
-              <article key={id}>
-                <Card handleClick={() => handleSelectLocation(location)}>
-                  <Card.Text>
-                    <Card.Detail>{placeName}</Card.Detail>
-                    <Card.Metadata>도로명: {roadAddressName}</Card.Metadata>
-                    <Card.Metadata>지번: {addressName}</Card.Metadata>
-                    <Card.Metadata>연락처: {phone}</Card.Metadata>
-                  </Card.Text>
-                </Card>
-              </article>
-            );
-          }}
-        </LocationSearchForm>
+        <div className={styles.modalContent}>
+          <LocationSearchForm keyword={keyword} handleSubmitKeyword={handleSubmitKeyword}>
+            {(location) => {
+              const { id, placeName, roadAddressName, addressName, phone } = location;
+              return (
+                <article key={id}>
+                  <Card handleClick={() => handleSelectLocation(location)}>
+                    <Card.Text>
+                      <Card.Detail>{placeName}</Card.Detail>
+                      <Card.Metadata>도로명: {roadAddressName}</Card.Metadata>
+                      <Card.Metadata>지번: {addressName}</Card.Metadata>
+                      <Card.Metadata>연락처: {phone}</Card.Metadata>
+                    </Card.Text>
+                  </Card>
+                </article>
+              );
+            }}
+          </LocationSearchForm>
+        </div>
       </Modal.Content>
       <Modal.RightButton onClick={handleCloseModal}>닫기</Modal.RightButton>
     </Modal>

--- a/src/features/moment/api/getMomentParticipantList.ts
+++ b/src/features/moment/api/getMomentParticipantList.ts
@@ -1,0 +1,23 @@
+import { UserJson } from '@/entities/user/model/types';
+import { privateClient } from '@/shared/api/config';
+import { InfiniteScroll } from '@/shared/types/api';
+
+export interface GetMomentParticipantListRequest {
+  momentId: number;
+  size: number;
+  page: number;
+}
+
+export const getMomentParticipantList = async ({
+  momentId,
+  page,
+  size,
+}: GetMomentParticipantListRequest): Promise<InfiniteScroll<UserJson>> => {
+  const { data: response } = await privateClient.get(`moment/${momentId}/members`, {
+    params: {
+      page: page,
+      size: size,
+    },
+  });
+  return response.data;
+};

--- a/src/features/moment/query/momentFeatureQueries.ts
+++ b/src/features/moment/query/momentFeatureQueries.ts
@@ -1,20 +1,35 @@
-import { Pagination } from '@/shared/types/api';
+import { InfiniteScroll, Pagination } from '@/shared/types/api';
 import { getCrewMomentList, GetCrewMomentListRequest } from '../api/getCrewMomentList';
-import { queryOptions } from '@tanstack/react-query';
+import { infiniteQueryOptions, QueryFunctionContext, queryOptions } from '@tanstack/react-query';
 import { MomentJSONType } from '@/entities/moment/model/types';
 import { momentQueries } from '@/entities/moment/query/momentQueries';
 import { getMomentPlaces, GetMomentPlacesRequest } from '../api/getMomentPlaces';
 import { getUpcomingMoments, GetUpcomingMomentsRequest } from '../api/getUpcomingMoments';
+import { getMomentParticipantList, GetMomentParticipantListRequest } from '../api/getMomentParticipantList';
+import { UserJson } from '@/entities/user/model/types';
 
 export const momentFeatureQueries = {
   allListKeys: [...momentQueries.allKeys, 'list'] as const,
   allPlacesKeys: [...momentQueries.allKeys, 'place'] as const,
+  allParticipantKeys: [...momentQueries.allKeys, 'participant'] as const,
+
+  participantsInfiniteJSON: ({ page, size, momentId }: GetMomentParticipantListRequest) =>
+    infiniteQueryOptions<InfiniteScroll<UserJson>>({
+      queryKey: [...momentFeatureQueries.allParticipantKeys, momentId, page, size],
+      queryFn: async ({ pageParam }: QueryFunctionContext) => {
+        const currentPage = typeof pageParam === 'number' ? pageParam : 1;
+        return await getMomentParticipantList({ page: currentPage, size, momentId });
+      },
+      initialPageParam: page,
+      getNextPageParam: (lastPage) => (lastPage.last ? undefined : lastPage.number + 1),
+    }),
 
   crewMomentPaginationJSON: ({ page, size, crewId }: GetCrewMomentListRequest) =>
     queryOptions<Pagination<MomentJSONType>>({
       queryKey: [...momentFeatureQueries.allListKeys, crewId, page, size],
       queryFn: () => getCrewMomentList({ crewId, page, size }),
     }),
+
   upcomingMomentsJSON: ({ page, size }: GetUpcomingMomentsRequest) =>
     queryOptions({
       queryKey: [...momentFeatureQueries.allListKeys, 'json', page, size],

--- a/src/features/moment/ui/MomentParticipantsModal/index.module.scss
+++ b/src/features/moment/ui/MomentParticipantsModal/index.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   gap: $space-xs;
-  max-height: 24rem;
+  height: 24rem;
   overflow: auto;
 }
 


### PR DESCRIPTION
## 🔥 PR 개요

<!-- PR의 목적을 간략히 설명해주세요. -->

- 모먼트 참여자 목록 api 연동 
- 무한 스크롤 기능 개선 및 버그 수정


## 📌 주요 변경 사항

<!-- 변경된 내용을 상세히 적어주세요. -->

### 무한 스크롤 기능 개선
- 데이터가 모두 한 번에 로드되는 버그 수정
- 모달 컨텐츠에서도 무한 스크롤이 올바르게 작동하도록 수정
 - 모달의 height 값을 명확히 지정하여 스크롤 영역 확보
- useInfiniteScroll 훅 리팩토링
 - rootRef와 targetRef를 훅 내부에서 관리하도록 변경
 - 제네릭 타입 추가로 다양한 HTML 요소에 사용 가능하도록 개선

### 모먼트 참여자 목록 기능 구현
- 참여자 목록 조회 API 연동
- 모달 내에서 무한 스크롤로 참여자 목록 로드

## 🔗 관련 이슈

- Closes #62 

## 🔍 테스트 방법

<!-- 변경된 기능을 테스트하는 방법을 설명해주세요. -->

1. `yarn dev` 실행
2. 로그인 
3. 크루 생성
4. 모먼트 생성
5. 모먼트 참여자 보기 

## 📷 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

## 📢 리뷰 요구 사항 (선택)

<!-- 리뷰어에게 요구 사항이 있다면 적어주세요.. -->

## 📜 기타 참고 사항 (선택)

<!-- 추가적으로 참고할 사항이 있다면 적어주세요. -->

## ✅ 체크리스트

<!-- 아래 항목을 확인하고 `[x]`로 표시해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 관련 이슈를 Closes #이슈번호로 닫았나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 관련 문서를 업데이트했나요?
