### PR TITLE
[FEAT] 초대 메일 관련 인증 로직 구축 

### DIFF
--- a/src/pages/AuthPage/index.tsx
+++ b/src/pages/AuthPage/index.tsx
@@ -11,7 +11,10 @@ function AuthPage() {
   useEffect(() => {
     const requestAuthorization = async () => {
       if (userId) await postAuth(userId);
-      navigate(routePaths.main);
+      const redirectURL = sessionStorage.getItem('redirectAfterOAuth');
+      sessionStorage.removeItem('redirectAfterOAuth');
+      if (redirectURL) navigate(redirectURL);
+      else navigate(routePaths.main);
     };
     requestAuthorization();
   }, [userId]);

--- a/src/pages/MemberJoinPage/index.tsx
+++ b/src/pages/MemberJoinPage/index.tsx
@@ -1,20 +1,40 @@
 import { usePostCrewJoin } from '@/entities/member/query/usePostCrewJoin';
+import { useAuth } from '@/features/auth/model/useAuth';
+import { AxiosError } from 'axios';
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 function MemberJoinPage() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
+  const oauth = searchParams.get('oauth') as 'naver' | 'google' | 'kakao';
   const navigate = useNavigate();
   const { mutateAsync } = usePostCrewJoin();
+  const { handleSocialSignIn } = useAuth();
 
   useEffect(() => {
     const joinCrew = async () => {
-      const { crewId } = await mutateAsync({ token: token || '' });
-      navigate(`/home/${crewId}`);
+      try {
+        const { crewId } = await mutateAsync({ token: token || '' });
+        navigate(`/home/${crewId}`);
+      } catch (error) {
+        if (error instanceof AxiosError) {
+          if (
+            error.response?.data?.code === 'JWT_NOT_FOUND_IN_COOKIE' ||
+            error.response?.data?.code === 'TOKEN_HIJACKED'
+          ) {
+            // 인증 완료 후 리다이렉트 할 현재 url 저장
+            const redirectPath = window.location.pathname + window.location.search;
+            sessionStorage.setItem('redirectAfterOAuth', redirectPath);
+
+            // oauth에 맞는 경로로 인증 리다이렉트
+            handleSocialSignIn(oauth);
+          }
+        }
+      }
     };
     joinCrew();
-  }, [token, mutateAsync]);
+  }, [token, mutateAsync, oauth]);
 
   return <></>;
 }


### PR DESCRIPTION
## 🔥 PR 개요

<!-- PR의 목적을 간략히 설명해주세요. -->

- 초대 메일 관련 인증 로직 구축 

## 📌 주요 변경 사항

<!-- 변경된 내용을 상세히 적어주세요. -->

- 초대 메일의 링크를 클릭하면, 쿼리스트링에 포함된 `token`과 `oauth`(소셜 종류)를 통해 초대 승낙 요청을 시도합니다.
- 인증되지 않은 상태에서 초대 승낙 요청 시:
  - 현재 경로(`window.location.pathname + window.location.search`)를 `sessionStorage`에 `redirectAfterOAuth` 키로 저장
  - 전달받은 소셜 종류에 맞는 로그인 URL로 이동
- 소셜 로그인 성공 후:
  - `AuthPage`에서 `sessionStorage`에 저장된 `redirectAfterOAuth` 값을 가져와 해당 경로로 이동
  - 이후 초대 승낙 로직이 다시 실행되며, 정상적으로 승낙 처리됨

## 🔗 관련 이슈

- Closes #80 

## 🔍 테스트 방법

<!-- 변경된 기능을 테스트하는 방법을 설명해주세요. -->

1. `yarn dev` 실행
2. 로그인
3. 크루 생성
4. 크루 멤버 초대
5. 초대 메일 버튼 클릭 

## 📷 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

## 📢 리뷰 요구 사항 (선택)

<!-- 리뷰어에게 요구 사항이 있다면 적어주세요.. -->

## 📜 기타 참고 사항 (선택)

<!-- 추가적으로 참고할 사항이 있다면 적어주세요. -->

## ✅ 체크리스트

<!-- 아래 항목을 확인하고 `[x]`로 표시해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 관련 이슈를 Closes #이슈번호로 닫았나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 관련 문서를 업데이트했나요?
