### PR TITLE
[FEAT] 헤더에 닉네임 프로필 이미지 띄우기

### DIFF
--- a/src/app/layouts/Header/index.module.scss
+++ b/src/app/layouts/Header/index.module.scss
@@ -11,7 +11,7 @@
   gap: $space-xs;
 }
 
-.icon-button {
+.header__button {
   display: inline-flex;
   justify-content: center;
   align-items: center;

--- a/src/app/layouts/Header/index.tsx
+++ b/src/app/layouts/Header/index.tsx
@@ -5,10 +5,13 @@ import { useContext } from 'react';
 import { ThemeContext } from '@/shared/contexts/ThemeContext';
 import { useNavigate } from 'react-router-dom';
 import { routePaths } from '@/app/routes/path';
+import ProfileImageBase from '@/entities/user/ui/ProfileImageBase';
+import useUserStore from '@/shared/store/userStore';
 
 function Header() {
   const themeContext = useContext(ThemeContext);
   const navigate = useNavigate();
+  const profileImage = useUserStore((state) => state.profileImage);
 
   const handleClickLogo = () => {
     navigate(routePaths.main);
@@ -18,15 +21,14 @@ function Header() {
     <header className={styles.header}>
       <Logo as="button" handleClick={handleClickLogo} size="md" />
       <div className={styles.headerUserActions}>
-        <button onClick={themeContext?.toggleTheme} className={styles.iconButton}>
-          <Icon icon="theme" iconSize="24" color="text-primary" />
+        <button onClick={themeContext?.toggleTheme} className={styles.headerButton}>
+          <Icon icon="theme" iconSize="28" color="text-primary" />
         </button>
-
-        {/*         <button>
-          <ProfileImage size="small" src={fallbackSource} />
+        {/*         <button className={styles.headerButton}>
+          <Icon iconSize="28" icon="alarm" color="text-secondary" />
         </button> */}
-        <button className={styles.iconButton}>
-          <Icon iconSize="24" icon="alarm" color="text-secondary" />
+        <button className={styles.headerButton}>
+          <ProfileImageBase size="small" src={profileImage || ''} />
         </button>
       </div>
     </header>

--- a/src/features/auth/api/postAuth.ts
+++ b/src/features/auth/api/postAuth.ts
@@ -1,7 +1,17 @@
 import { privateClient } from '@/shared/api/config';
+import { formatImageSource } from '@/shared/helper/formatImageSource';
 
 export const postAuth = async (userId: number) => {
-  await privateClient.post(`auth`, {
+  const { data: response } = await privateClient.post(`auth`, {
     userId: userId,
   });
+
+  const { nickname, fileResponse } = response.data;
+  const { fileEnv, source } = fileResponse;
+  const formattedProfileImage = formatImageSource(fileEnv, source);
+
+  return {
+    nickname,
+    profileImage: formattedProfileImage,
+  };
 };

--- a/src/features/auth/ui/SignUpForm/index.tsx
+++ b/src/features/auth/ui/SignUpForm/index.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { postAuth } from '../../api/postAuth';
 import { routePaths } from '@/app/routes/path';
 import { FormEvent } from 'react';
+import useUserStore from '@/shared/store/userStore';
 
 interface SignUpForm extends UserInfoType {
   token: string;
@@ -28,6 +29,7 @@ function SignUpForm({ nickname, image, token }: SignUpForm) {
     handleNicknameDuplicateCheck,
   } = useProfileRegister({ nickname, image });
   const navigate = useNavigate();
+  const updateUser = useUserStore((state) => state.update);
 
   const watchedFile = useWatch({ control, name: 'image' });
   const watchedNickname = useWatch({ control, name: 'nickname' });
@@ -39,7 +41,8 @@ function SignUpForm({ nickname, image, token }: SignUpForm) {
     if (!canSubmit) return;
     const nickname = getValues('nickname');
     const { userId } = await postAuthSignup(token, nickname);
-    await postAuth(userId);
+    const { profileImage } = await postAuth(userId);
+    updateUser({ nickname, profileImage });
     navigate(routePaths.main);
   };
 

--- a/src/pages/AuthPage/index.tsx
+++ b/src/pages/AuthPage/index.tsx
@@ -1,5 +1,7 @@
 import { routePaths } from '@/app/routes/path';
 import { postAuth } from '@/features/auth/api/postAuth';
+import { SESSION_STORAGE_KEY } from '@/shared/constants/storageKey';
+import useUserStore from '@/shared/store/userStore';
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -7,12 +9,16 @@ function AuthPage() {
   const [searchParams] = useSearchParams();
   const userId = Number(searchParams.get('id'));
   const navigate = useNavigate();
+  const updateUser = useUserStore((state) => state.update);
 
   useEffect(() => {
     const requestAuthorization = async () => {
-      if (userId) await postAuth(userId);
-      const redirectURL = sessionStorage.getItem('redirectAfterOAuth');
-      sessionStorage.removeItem('redirectAfterOAuth');
+      const { nickname, profileImage } = await postAuth(userId);
+      updateUser({ nickname, profileImage });
+
+      const redirectURL = sessionStorage.getItem(SESSION_STORAGE_KEY.REDIRECT_AFTER_OAUTH);
+      sessionStorage.removeItem(SESSION_STORAGE_KEY.REDIRECT_AFTER_OAUTH);
+
       if (redirectURL) navigate(redirectURL);
       else navigate(routePaths.main);
     };

--- a/src/shared/constants/storageKey.ts
+++ b/src/shared/constants/storageKey.ts
@@ -1,0 +1,7 @@
+export const LOCAL_STORAGE_KEY = {
+  USER_STORAGE: 'HW_USER_STORAGE',
+} as const;
+
+export const SESSION_STORAGE_KEY = {
+  REDIRECT_AFTER_OAUTH: 'HW_REDIRECT_AFTER_OAUTH',
+} as const;

--- a/src/shared/store/userStore.ts
+++ b/src/shared/store/userStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { LOCAL_STORAGE_KEY } from '../constants/storageKey';
+
+interface UserState {
+  nickname: string;
+  profileImage: string;
+}
+
+interface UserAction {
+  update: (user: UserState) => void;
+  clear: () => void;
+}
+
+interface UserStore extends UserState, UserAction {}
+
+const useUserStore = create(
+  persist<UserStore>(
+    (set) => ({
+      nickname: '',
+      profileImage: '',
+      update: ({ nickname, profileImage }) => set({ nickname, profileImage }),
+      clear: () => set({ nickname: '', profileImage: '' }), // 상태 초기화
+    }),
+    {
+      name: LOCAL_STORAGE_KEY.USER_STORAGE, // 로컬 스토리지 키
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+
+export default useUserStore;


### PR DESCRIPTION
## 🔥 PR 개요

<!-- PR의 목적을 간략히 설명해주세요. -->

- 헤더에 닉네임 프로필 이미지 띄우기

## 📌 주요 변경 사항

<!-- 변경된 내용을 상세히 적어주세요. -->

- api/auth 응답 데이터를 받아 nickanme과 profileImage를 localStorage에 저장하는 로직 추가
- zustand의 persist 미들웨어를 사용하여 nickname과 profileImage 상태를 관리하고, 로컬 스토리지에 저장하여 새로고침해도 사용자 정보가 유지되도록 함 

## 🔗 관련 이슈

- Closes #102 

## 🔍 테스트 방법

<!-- 변경된 기능을 테스트하는 방법을 설명해주세요. -->

1. `yarn dev` 실행
2. 로그인

## 📷 스크린샷 (선택)

<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

## 📢 리뷰 요구 사항 (선택)

<!-- 리뷰어에게 요구 사항이 있다면 적어주세요.. -->

## 📜 기타 참고 사항 (선택)

<!-- 추가적으로 참고할 사항이 있다면 적어주세요. -->

## ✅ 체크리스트

<!-- 아래 항목을 확인하고 `[x]`로 표시해주세요. -->

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 관련 이슈를 Closes #이슈번호로 닫았나요?
- [x] Reviewers, Labels를 등록했나요?
- [x] 불필요한 코드는 제거했나요?
- [x] 코드 스타일 가이드를 준수했나요?
- [x] 관련 문서를 업데이트했나요?
